### PR TITLE
ldap_configurator.py needs download_custom_schema()

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,13 +10,13 @@ download_custom_schema() {
 }
 
 if [ ! -f /touched ]; then
+    download_custom_schema
     python /ldap/scripts/ldap_configurator.py
     touch /touched
 fi
 
 mkdir -p /flag
 if [ ! -f /flag/ldap_initialized ]; then
-    download_custom_schema
     python /ldap/scripts/ldap_initializer.py
     touch /flag/ldap_initialized
 fi


### PR DESCRIPTION
- ldap_initializer.py doesn't need it

- This fixed a problem where the /ldap/custom_schema directory
  wasn't populated in time for ldap_configurator.py being run.